### PR TITLE
EC-CUBE4.1 対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ env:
     - ECCUBE_VERSION=4.0.2 DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
     - ECCUBE_VERSION=4.0.3 DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
     - ECCUBE_VERSION=4.0.3 DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
+    - ECCUBE_VERSION=4.1 DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
+    - ECCUBE_VERSION=4.1 DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
 matrix:
   exclude:
     - php: 7.3
@@ -66,7 +68,7 @@ matrix:
       env: ECCUBE_VERSION=4.0.3 DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
     - php: 7.4
       env: ECCUBE_VERSION=4.0.3 DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
-    
+
 before_install: &php_setup |
   phpenv config-rm xdebug.ini || true
   echo "opcache.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -74,12 +76,13 @@ before_install: &php_setup |
   echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install_eccube: &install_eccube |
+  sh -c "if [ ! '${ECCUBE_VERSION}' = '4.1' ]; then  composer selfupdate --1; fi"
+  sh -c "if [ '${ECCUBE_VERSION}' = '4.1' ]; then  composer selfupdate; fi"
   tar cvzf ${HOME}/${PLUGIN_CODE}.tar.gz ./*
   git clone https://github.com/EC-CUBE/ec-cube.git
   cd ec-cube
-  sh -c "if [ '${ECCUBE_VERSION}' = '4.0' ];   then git checkout origin/${ECCUBE_VERSION}; fi"
+  sh -c "if [ '${ECCUBE_VERSION}' = '4.0' ] || [ '${ECCUBE_VERSION}' = '4.1' ];   then git checkout origin/${ECCUBE_VERSION}; fi"
   sh -c "if [ ! '${ECCUBE_VERSION}' = '4.0' ]; then git checkout refs/tags/${ECCUBE_VERSION}; fi"
-  composer selfupdate
   composer install --dev --no-interaction -o --apcu-autoloader
 
 eccube_setup: &eccube_setup |
@@ -93,9 +96,18 @@ eccube_setup: &eccube_setup |
 install:
   - *install_eccube
   - *eccube_setup
+  - composer require --dev kiy0taka/eccube4-test-fixer
 
-script:
-  -  ./vendor/bin/phpunit app/Plugin/${PLUGIN_CODE}/Tests;
+script: |
+   if [[ ! $ECCUBE_VERSION = '4.1' ]]
+   then
+     find app/Plugin/${PLUGIN_CODE}/Tests -name "*Test.php" | while read TESTCASE
+     do
+       ./vendor/bin/phpunit --include-path vendor/kiy0taka/eccube4-test-fixer/src --loader 'Eccube\PHPUnit\Loader\Eccube4CompatTestSuiteLoader' ${TESTCASE}
+     done
+   else
+     ./vendor/bin/phpunit app/Plugin/${PLUGIN_CODE}/Tests
+   fi
 
 after_script:
   # disable plugin

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -37,7 +37,7 @@ class PluginManager extends AbstractPluginManager
 
     public function enable(array $meta, ContainerInterface $container)
     {
-        $em = $container->get('doctrine.orm.entity_manager');
+        $em = $container->get('doctrine')->getManager();
 
         // プラグイン設定を追加
         $Config = $this->createConfig($em);
@@ -57,7 +57,7 @@ class PluginManager extends AbstractPluginManager
 
         // ページを追加
         foreach ($this->urls as $url => $name) {
-            $Page = $container->get(PageRepository::class)->findOneBy(['url' => $url]);
+            $Page = $em->getRepository(Page::class)->findOneBy(['url' => $url]);
             if (null === $Page) {
                 $this->createPage($em, $name, $url);
             }
@@ -66,7 +66,7 @@ class PluginManager extends AbstractPluginManager
 
     public function uninstall(array $meta, ContainerInterface $container)
     {
-        $em = $container->get('doctrine.orm.entity_manager');
+        $em = $container->get('doctrine')->getManager();
 
         // ページを削除
         foreach ($this->urls as $url) {

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -12,7 +12,7 @@ product_review.common.required: 必須
 product_review.admin.config.title: レビュー設定
 product_review.admin.config.sub_title: プラグイン一覧
 product_review.admin.config.config_title: 設定
-product_review.admin.config.review_max: レビューの表示件数(%min%〜%max%)
+product_review.admin.config.review_max: 'レビューの表示件数(%min%〜%max%)'
 product_review.admin.config.conversion.save: 登録
 product_review.admin.config.conversion.back: プラグイン一覧
 
@@ -22,7 +22,7 @@ product_review.admin.product_review.sub_title: 商品管理
 product_review.admin.product_review.search_detail: 詳細検索
 product_review.admin.product_review.search_button: 検索
 product_review.admin.product_review.search_clear: 検索条件をクリア
-product_review.admin.product_review.search_result_count: 検索結果：%count%件が該当しました。
+product_review.admin.product_review.search_result_count: '検索結果：%count%件が該当しました。'
 product_review.admin.product_review.search_multi: 投稿者名・投稿者URL
 product_review.admin.product_review.search_product_name: 商品名
 product_review.admin.product_review.search_product_code: 商品コード
@@ -36,7 +36,7 @@ product_review.admin.product_review.search_no_result: 検索条件に合致す�
 product_review.admin.product_review.search_invalid_condition: 検索条件に誤りがあります
 product_review.admin.product_review.search_change_condition_and_retry: 検索条件を変えて、再度検索をお試しください。
 product_review.admin.product_review.search_try_detail_condition: '[詳細検索]も試してみましょう。'
-product_review.admin.product_review.diaply_count: %count%件
+product_review.admin.product_review.diaply_count: '%count%件'
 product_review.admin.product_review.csv_download: CSVダウンロード
 product_review.admin.product_review.csv_download_setting: CSV出力項目設定
 product_review.admin.product_review.th_posted_date: 投稿日
@@ -90,8 +90,4 @@ product_review.form.product_review.recommend_level: おすすめレベル
 product_review.front.product_detail.title: この商品のレビュー
 product_review.front.product_detail.no_review: レビューはありません。
 product_review.front.product_detail.post_review: レビューを投稿
-product_review.front.product_detail.name: %name% さん
-
-
-
-
+product_review.front.product_detail.name: '%name% さん'

--- a/Tests/Web/ProductReviewConfigControllerTest.php
+++ b/Tests/Web/ProductReviewConfigControllerTest.php
@@ -80,7 +80,7 @@ class ProductReviewConfigControllerTest extends AbstractAdminWebTestCase
         $form['product_review_config[review_max]'] = $this->faker->numberBetween(-10, $min - 1);
         $crawler = $client->submit($form);
 
-        $this->assertContains($min.'以上でなければなりません。', $crawler->html());
+        $this->assertContains($min.'以上', $crawler->html());
     }
 
     /**

--- a/Tests/Web/ReviewAdminControllerTest.php
+++ b/Tests/Web/ReviewAdminControllerTest.php
@@ -13,6 +13,7 @@
 
 namespace Plugin\ProductReview4\Tests\Web;
 
+use Eccube\Entity\Master\Sex;
 use Eccube\Entity\Product;
 use Eccube\Repository\Master\ProductStatusRepository;
 use Eccube\Repository\Master\SexRepository;
@@ -24,6 +25,7 @@ use Plugin\ProductReview4\Entity\ProductReviewStatus;
 use Plugin\ProductReview4\Repository\ProductReviewRepository;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
+
 
 /**
  * Class ReviewAdminControllerTest.
@@ -59,9 +61,9 @@ class ReviewAdminControllerTest extends AbstractAdminWebTestCase
         $this->faker = $this->getFaker();
         $this->deleteAllRows(['plg_product_review']);
 
-        $this->productRepo = $this->container->get(ProductRepository::class);
-        $this->sexMasterRepo = $this->container->get(SexRepository::class);
-        $this->productReviewRepo = $this->container->get(ProductReviewRepository::class);
+        $this->productRepo = $this->entityManager->getRepository(Product::class);
+        $this->sexMasterRepo = $this->entityManager->getRepository(Sex::class);
+        $this->productReviewRepo = $this->entityManager->getRepository(ProductReview::class);
     }
 
     /**

--- a/Tests/Web/ReviewControllerTest.php
+++ b/Tests/Web/ReviewControllerTest.php
@@ -13,6 +13,7 @@
 
 namespace Plugin\ProductReview4\Tests\Web;
 
+use Eccube\Entity\Master\Sex;
 use Eccube\Entity\Product;
 use Eccube\Repository\Master\ProductStatusRepository;
 use Eccube\Repository\Master\SexRepository;
@@ -23,6 +24,7 @@ use Plugin\ProductReview4\Entity\ProductReview;
 use Plugin\ProductReview4\Entity\ProductReviewStatus;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
 
 /**
  * Class ReviewControllerTest front.
@@ -58,9 +60,9 @@ class ReviewControllerTest extends AbstractWebTestCase
         $this->faker = $this->getFaker();
         $this->deleteAllRows(['plg_product_review']);
 
-        $this->productRepo = $this->container->get(ProductRepository::class);
-        $this->sexMasterRepo = $this->container->get(SexRepository::class);
-        $this->productStatusRepo = $this->container->get(ProductStatusRepository::class);
+        $this->productRepo = $this->entityManager->getRepository(Product::class);
+        $this->sexMasterRepo = $this->entityManager->getRepository(Sex::class);
+        $this->productReviewRepo = $this->entityManager->getRepository(ProductReview::class);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "ec-cube/ProductReview4",
+    "name": "ec-cube/productreview4",
     "version": "4.0.1",
     "description": "商品レビュー管理プラグイン",
     "type": "eccube-plugin",
     "require": {
-        "ec-cube/plugin-installer": "~0.0.6"
+        "ec-cube/plugin-installer": "~0.0.6 || ^2.0@dev"
     },
     "extra": {
         "code": "ProductReview4"


### PR DESCRIPTION
- Tests/Web/ProductReviewConfigControllerTest.php の修正は、 Symfony4.4 からエラーメッセージが「○以上○以下でなければなりません」に変更されたため。
- テストケースの上位互換を修正
- composer 2.0 対応