### PR TITLE
ページ管理でテンプレートが編集できない問題を修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,13 +73,18 @@ before_install: &php_setup |
   echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
+# composer.jsonが存在しないディレクトリで実行
+setup_composer: &setup_composer |
+  cd ..
+  composer selfupdate --1
+  cd -
+
 install_eccube: &install_eccube |
   tar cvzf ${HOME}/${PLUGIN_CODE}.tar.gz ./*
   git clone https://github.com/EC-CUBE/ec-cube.git
   cd ec-cube
   sh -c "if [ '${ECCUBE_VERSION}' = '4.0' ];   then git checkout origin/${ECCUBE_VERSION}; fi"
   sh -c "if [ ! '${ECCUBE_VERSION}' = '4.0' ]; then git checkout refs/tags/${ECCUBE_VERSION}; fi"
-  composer selfupdate --1
   composer install --dev --no-interaction -o --apcu-autoloader
 
 eccube_setup: &eccube_setup |
@@ -91,6 +96,7 @@ eccube_setup: &eccube_setup |
   bin/console eccube:plugin:enable --code=${PLUGIN_CODE}
 
 install:
+  - *setup_composer
   - *install_eccube
   - *eccube_setup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
       env: ECCUBE_VERSION=4.0.3 DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
     - php: 7.4
       env: ECCUBE_VERSION=4.0.3 DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
-    
+
 before_install: &php_setup |
   phpenv config-rm xdebug.ini || true
   echo "opcache.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -79,7 +79,7 @@ install_eccube: &install_eccube |
   cd ec-cube
   sh -c "if [ '${ECCUBE_VERSION}' = '4.0' ];   then git checkout origin/${ECCUBE_VERSION}; fi"
   sh -c "if [ ! '${ECCUBE_VERSION}' = '4.0' ]; then git checkout refs/tags/${ECCUBE_VERSION}; fi"
-  composer selfupdate
+  composer selfupdate --1
   composer install --dev --no-interaction -o --apcu-autoloader
 
 eccube_setup: &eccube_setup |

--- a/Controller/ProductReviewController.php
+++ b/Controller/ProductReviewController.php
@@ -59,6 +59,7 @@ class ProductReviewController extends AbstractController
 
     /**
      * @Route("/product_review/{id}/review", name="product_review_index", requirements={"id" = "\d+"})
+     * @Route("/product_review/{id}/review", name="product_review_confirm", requirements={"id" = "\d+"})
      *
      * @param Request $request
      * @param Product $Product
@@ -85,7 +86,7 @@ class ProductReviewController extends AbstractController
                 case 'confirm':
                     log_info('Product review config confirm');
 
-                    return $this->render('@ProductReview4/default/confirm.twig', [
+                    return $this->render('ProductReview4/Resource/template/default/confirm.twig', [
                         'form' => $form->createView(),
                         'Product' => $Product,
                         'ProductReview' => $ProductReview,
@@ -118,7 +119,7 @@ class ProductReviewController extends AbstractController
             }
         }
 
-        return $this->render('@ProductReview4/default/index.twig', [
+        return $this->render('ProductReview4/Resource/template/default/index.twig', [
             'Product' => $Product,
             'ProductReview' => $ProductReview,
             'form' => $form->createView(),
@@ -129,7 +130,7 @@ class ProductReviewController extends AbstractController
      * Complete.
      *
      * @Route("/product_review/{id}/complete", name="product_review_complete", requirements={"id" = "\d+"})
-     * @Template("@ProductReview4/default/complete.twig")
+     * @Template("ProductReview4/Resource/template/default/complete.twig")
      *
      * @param $id
      *
@@ -138,5 +139,15 @@ class ProductReviewController extends AbstractController
     public function complete($id)
     {
         return ['id' => $id];
+    }
+
+    /**
+     * ページ管理表示用のダミールーティング.
+     *
+     * @Route("/product_review/display", name="product_review_display")
+     */
+    public function display()
+    {
+        return new Response();
     }
 }

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -14,6 +14,7 @@
 namespace Plugin\ProductReview4;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Csv;
 use Eccube\Entity\Layout;
 use Eccube\Entity\Master\CsvType;
@@ -24,15 +25,31 @@ use Eccube\Repository\PageRepository;
 use Plugin\ProductReview4\Entity\ProductReviewConfig;
 use Plugin\ProductReview4\Entity\ProductReviewStatus;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 class PluginManager extends AbstractPluginManager
 {
-    /**
-     * @var array
-     */
-    private $urls = [
-        'product_review_index' => 'レビューを投稿',
-        'product_review_complete' => 'レビューを投稿(完了)',
+    private $pages = [
+        [
+            'name' => 'レビューを表示',
+            'url' => 'product_review_display',
+            'filename' => 'ProductReview4/Resource/template/default/review',
+        ],
+        [
+            'name' => 'レビューを投稿',
+            'url' => 'product_review_index',
+            'filename' => 'ProductReview4/Resource/template/default/index',
+        ],
+        [
+            'name' => 'レビューを投稿(確認)',
+            'url' => 'product_review_confirm',
+            'filename' => 'ProductReview4/Resource/template/default/confirm',
+        ],
+        [
+            'name' => 'レビューを投稿(完了)',
+            'url' => 'product_review_complete',
+            'filename' => 'ProductReview4/Resource/template/default/complete',
+        ],
     ];
 
     public function enable(array $meta, ContainerInterface $container)
@@ -56,11 +73,23 @@ class PluginManager extends AbstractPluginManager
         }
 
         // ページを追加
-        foreach ($this->urls as $url => $name) {
-            $Page = $container->get(PageRepository::class)->findOneBy(['url' => $url]);
+        foreach ($this->pages as $pageInfo) {
+            $Page = $container->get(PageRepository::class)->findOneBy(['url' => $pageInfo['url']]);
             if (null === $Page) {
-                $this->createPage($em, $name, $url);
+                $this->createPage($em, $pageInfo['name'], $pageInfo['url'], $pageInfo['filename']);
             }
+        }
+
+        $this->copyTwigFiles($container);
+    }
+
+    public function disable(array $meta, ContainerInterface $container)
+    {
+        $em = $container->get('doctrine.orm.entity_manager');
+
+        // ページを削除
+        foreach ($this->pages as $pageInfo) {
+            $this->removePage($em, $pageInfo['url']);
         }
     }
 
@@ -69,9 +98,11 @@ class PluginManager extends AbstractPluginManager
         $em = $container->get('doctrine.orm.entity_manager');
 
         // ページを削除
-        foreach ($this->urls as $url) {
-            $this->removePage($em, $url);
+        foreach ($this->pages as $pageInfo) {
+            $this->removePage($em, $pageInfo['url']);
         }
+
+        $this->removeTwigFiles($container);
 
         $Config = $em->find(ProductReviewConfig::class, 1);
         if ($Config) {
@@ -149,13 +180,13 @@ class PluginManager extends AbstractPluginManager
         return $CsvType;
     }
 
-    protected function createPage(EntityManagerInterface $em, $name, $url)
+    protected function createPage(EntityManagerInterface $em, $name, $url, $filename)
     {
         $Page = new Page();
         $Page->setEditType(Page::EDIT_TYPE_DEFAULT);
         $Page->setName($name);
         $Page->setUrl($url);
-        $Page->setFileName('@ProductReview4/default/index');
+        $Page->setFileName($filename);
 
         // DB登録
         $em->persist($Page);
@@ -169,6 +200,18 @@ class PluginManager extends AbstractPluginManager
             ->setSortNo(0);
         $em->persist($PageLayout);
         $em->flush($PageLayout);
+    }
+
+    protected function copyTwigFiles(ContainerInterface $container)
+    {
+        $templatePath = $container->getParameter('eccube_theme_front_dir')
+            .'/ProductReview4/Resource/template/default';
+        $fs = new Filesystem();
+        if ($fs->exists($templatePath)) {
+            return;
+        }
+        $fs->mkdir($templatePath);
+        $fs->mirror(__DIR__.'/Resource/template/default', $templatePath);
     }
 
     protected function createCsvData(EntityManagerInterface $em, CsvType $CsvType)
@@ -289,6 +332,14 @@ class PluginManager extends AbstractPluginManager
 
         $em->remove($Page);
         $em->flush($Page);
+    }
+
+    protected function removeTwigFiles(ContainerInterface $container)
+    {
+        $templatePath = $container->getParameter('eccube_theme_front_dir')
+            .'/ProductReview4';
+        $fs = new Filesystem();
+        $fs->remove($templatePath);
     }
 
     protected function removeCsvData(EntityManagerInterface $em, CsvType $CsvType)

--- a/ProductReviewEvent.php
+++ b/ProductReviewEvent.php
@@ -65,7 +65,7 @@ class ProductReviewEvent implements EventSubscriberInterface
      */
     public function detail(TemplateEvent $event)
     {
-        $event->addSnippet('@ProductReview4/default/review.twig');
+        $event->addSnippet('ProductReview4/Resource/template/default/review.twig');
 
         $Config = $this->productReviewConfigRepository->get();
 

--- a/Resource/template/default/review.twig
+++ b/Resource/template/default/review.twig
@@ -1,4 +1,3 @@
-
 {#
 /*
  * This file is part of the ProductReview plugin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,6 +65,7 @@ install:
   - echo memory_limit = 512M >> C:\tools\php72\php.ini
   - echo APP_ENV=codeception >> .env
   - php -r "readfile('http://getcomposer.org/installer');" | php
+  - php composer.phar selfupdate --1
   - php composer.phar install --dev --no-interaction -o
 
 # Don't actually build.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ec-cube/ProductReview4",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "description": "商品レビュー管理プラグイン",
     "type": "eccube-plugin",
     "require": {


### PR DESCRIPTION
#61 #54 の修正

- テンプレートが編集できない問題を修正
  - 互換性維持のためクーポンプラグインの修正方針で対応(https://github.com/EC-CUBE/coupon-plugin/pull/126)
- レビュー表示のテンプレート(review.twig)をページに追加
- 不要な改行を削除

無効化/有効化でdtb_page/dtb_page_layoutを再生成するため、マイグレーションは作成していません。