### PR TITLE
return文の後の不要なbreak文を削除

### DIFF
--- a/Controller/ProductReviewController.php
+++ b/Controller/ProductReviewController.php
@@ -107,7 +107,6 @@ class ProductReviewController extends AbstractController
                     log_info('Product review complete', ['id' => $Product->getId()]);
 
                     return $this->redirectToRoute('product_review_complete', ['id' => $Product->getId()]);
-                    break;
 
                 case 'back':
                     // 確認画面から投稿画面へ戻る


### PR DESCRIPTION
return文の後にあるため到達不可能なbreak文を削除

- 修正箇所: Controller/ProductReviewController.php:110
- return文でメソッドを抜けるため、その後のbreak文は実行されない

コードの可読性とメンテナンス性の向上

Fixes #97