### PR TITLE
ci: 静的解析 (Rector / PHPStan / php-cs-fixer) の導入とキャッシュ残留フレークの修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,86 @@ jobs:
           PLUGIN_CODE: ${{ matrix.plugin_code }}
         working-directory: 'ec-cube'
         run: bin/console eccube:plugin:uninstall --code=${PLUGIN_CODE}
+
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-24.04
+    # 静的解析は DB 種別に依存しないため、SQLite 1 構成で一度だけ実行する。
+    # （php-cs-fixer / rector は DB 不要だが、phpstan は objectManagerLoader が
+    #   カーネルを起動し EccubeExtension が dtb_plugin を読むため本体+DBが必要）
+    env:
+      PLUGIN_CODE: ProductReview44
+      APP_ENV: 'test'
+      APP_DEBUG: 0
+      DATABASE_URL: 'sqlite:///var/eccube.db'
+      DATABASE_SERVER_VERSION: 3
+      DATABASE_CHARSET: 'utf8'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: '8.5'
+          # xdebug が有効だと解析が大幅に遅くなるため無効化する
+          extensions: ':xdebug'
+
+      - name: Archive Plugin
+        run: |
+          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz ./*
+      - name: Checkout EC-CUBE
+        uses: actions/checkout@v4
+        with:
+          repository: 'EC-CUBE/ec-cube'
+          ref: '4.4'
+          path: 'ec-cube'
+          persist-credentials: false
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install to composer
+        working-directory: 'ec-cube'
+        run: composer install --no-interaction -o --apcu-autoloader --ignore-platform-req=ext-redis
+
+      - name: Setup EC-CUBE
+        working-directory: 'ec-cube'
+        run: |
+          # SQLite はファイルベースで CREATE DATABASE が無く, DBAL 4 では
+          # SQLitePlatform::getCreateDatabaseSQL が未サポートで例外になるため
+          # doctrine:database:create は実行しない (schema:create が DB ファイルを生成する)。
+          bin/console doctrine:schema:create
+          # プラグイン有効化時に DeviceType 等のマスタデータを参照するため fixtures を投入する
+          bin/console eccube:fixtures:load
+      - name: Setup Plugin
+        working-directory: 'ec-cube'
+        run: |
+          bin/console eccube:plugin:install --code=${PLUGIN_CODE} --path=${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz
+          ## enable は ProductReviewConfig エンティティを参照するため、install 後に
+          ## cache:clear でマッピングを登録してから enable する（順序を入れ替えると MappingException）
+          bin/console cache:clear --no-warmup
+          bin/console eccube:plugin:enable --code=${PLUGIN_CODE}
+
+      - name: Run php-cs-fixer
+        working-directory: 'ec-cube'
+        run: ./vendor/bin/php-cs-fixer fix --config=app/Plugin/${PLUGIN_CODE}/Resource/.php-cs-fixer.dist.php --dry-run --diff
+
+      - name: Run Rector
+        working-directory: 'ec-cube'
+        run: ./vendor/bin/rector process --config=app/Plugin/${PLUGIN_CODE}/Resource/rector.php --dry-run
+
+      - name: Run PHPStan
+        working-directory: 'ec-cube'
+        run: |
+          bin/console cache:clear --no-warmup
+          ./vendor/bin/phpstan analyse -c app/Plugin/${PLUGIN_CODE}/phpstan.neon.dist --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,10 @@ jobs:
           PLUGIN_CODE: ${{ matrix.plugin_code }}
         working-directory: 'ec-cube'
         run: |
-          # 有効化したプラグインのルーティングはコンテナのコンパイル時に確定する。
-          # phpunit プロセスでの遅延コンパイルに任せると DB/タイミングで有効プラグイン一覧を
-          # 取りこぼし RouteNotFound になることがあるため、クリーンなプロセスで warmup して確定させる。
-          bin/console cache:clear --no-warmup
+          # cache:clear は秒精度の fresh 判定で有効化前のコンテナを残すことがあるため、直接削除して warmup する
+          rm -rf var/cache/test
           bin/console cache:warmup
-          # 有効プラグインのルートがコンテナに載っていることを確認する。
-          # EccubeExtension::configurePlugins() はビルド時の DB 接続に失敗すると
-          # 全プラグインを無効とみなして正常終了するため、warmup の成否では検知できない。
+          # 有効プラグインのルートがコンテナに載っていることを確認する (warmup の成否では検知できない)
           bin/console debug:router | grep -q product_review_index
           ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist app/Plugin/${PLUGIN_CODE}/Tests
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
         working-directory: ../
         run: |
           rm -rf $GITHUB_WORKSPACE/.github
+          # 静的解析の設定は配布パッケージに含めない
+          rm -f $GITHUB_WORKSPACE/phpstan.neon.dist
+          rm -f $GITHUB_WORKSPACE/Resource/rector.php "$GITHUB_WORKSPACE/Resource/.php-cs-fixer.dist.php"
           find $GITHUB_WORKSPACE -name "dummy" -delete
           find $GITHUB_WORKSPACE -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf
           chmod -R o+w $GITHUB_WORKSPACE

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# 静的解析・テストツールのキャッシュ
+.php-cs-fixer.cache
+.phpunit.result.cache

--- a/Controller/Admin/ProductReviewController.php
+++ b/Controller/Admin/ProductReviewController.php
@@ -43,9 +43,8 @@ class ProductReviewController extends AbstractController
         protected ProductReviewRepository $productReviewRepository,
         protected ProductReviewConfigRepository $productReviewConfigRepository,
         protected CsvExportService $csvExportService,
-        private readonly PaginatorInterface $paginator
-    )
-    {
+        private readonly PaginatorInterface $paginator,
+    ) {
     }
 
     /**

--- a/Resource/.php-cs-fixer.dist.php
+++ b/Resource/.php-cs-fixer.dist.php
@@ -1,0 +1,57 @@
+<?php
+
+if (php_sapi_name() !== 'cli') {
+    throw new \LogicException();
+}
+
+$header = <<<EOL
+This file is part of EC-CUBE
+
+Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+
+http://www.ec-cube.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOL;
+
+$rules = [
+    '@Symfony' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'phpdoc_align' => false,
+    'phpdoc_summary' => false,
+    'phpdoc_annotation_without_dot' => false,
+    'no_superfluous_phpdoc_tags' => false,
+    'increment_style' => false,
+    'yoda_style' => false,
+    'header_comment' => ['header' => $header],
+    'phpdoc_add_missing_param_annotation' => true,
+    'phpdoc_param_order' => true,
+    'phpdoc_to_comment' => false, // /** @var */ を変換してしまうため
+    'phpdoc_trim' => true,
+    'global_namespace_import' => [
+        'import_classes' => false,
+        'import_constants' => false,
+        'import_functions' => false,
+    ],
+    // PHPDocの型をネイティブ型へ
+    'phpdoc_to_param_type' => true,
+    'phpdoc_to_return_type' => true,
+    // プロパティのネイティブ型化は無効。EC-CUBE のテスト基盤が tearDown で全プロパティに
+    // null を代入するため、テストプロパティを非null native 型にすると TypeError になる。
+    'phpdoc_to_property_type' => false,
+];
+
+$finder = \PhpCsFixer\Finder::create()
+    ->in(dirname(__DIR__))
+    ->exclude(['vendor', 'node_modules', 'Resource'])
+    ->name('*.php')
+;
+$config = new \PhpCsFixer\Config();
+
+return $config
+    ->setRules($rules)
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+    ->setUnsupportedPhpVersionAllowed(true)
+;

--- a/Resource/rector.php
+++ b/Resource/rector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Symfony\Set\SymfonySetList;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+    // EC-CUBE 4.4 の最小サポートバージョンに合わせる
+    ->withPhpVersion(PhpVersion::PHP_82)
+    // プラグインのソースディレクトリ
+    ->withPaths([
+        dirname(__DIR__).'/Controller',
+        dirname(__DIR__).'/Entity',
+        dirname(__DIR__).'/Form',
+        dirname(__DIR__).'/Repository',
+        dirname(__DIR__).'/PluginManager.php',
+        dirname(__DIR__).'/ProductReviewEvent.php',
+        dirname(__DIR__).'/ProductReviewNav.php',
+    ])
+    ->withSkip([
+        dirname(__DIR__).'/vendor',
+        dirname(__DIR__).'/node_modules',
+    ])
+    ->withSets([
+        LevelSetList::UP_TO_PHP_82,
+        // Symfony 7.4 対応 (@Route → #[Route], @Template, buildForm(): void 等)
+        SymfonySetList::SYMFONY_74,
+        SymfonySetList::SYMFONY_CODE_QUALITY,
+        // Doctrine ORM 3.0 / DBAL 3.0 対応 (@ORM → #[ORM], 型付きプロパティ)
+        DoctrineSetList::DOCTRINE_CODE_QUALITY,
+        DoctrineSetList::DOCTRINE_DBAL_30,
+        DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
+    ])
+    // Symfony/Doctrine 等のアノテーション → アトリビュート変換を有効化
+    ->withAttributesSets()
+    // #[Route] は付与されるが use 文が旧 Annotation のまま残るため Attribute へ統一する
+    ->withConfiguredRule(RenameClassRector::class, [
+        'Symfony\Component\Routing\Annotation\Route' => 'Symfony\Component\Routing\Attribute\Route',
+    ])
+    ->withImportNames(
+        importShortClasses: false,
+        importDocBlockNames: true,
+        importNames: true
+    )
+    ->withParallel();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,17 @@
+parameters:
+    level: 6
+    paths:
+        - .
+    excludePaths:
+        - Resource/*
+        - Tests/bootstrap.php
+    doctrine:
+        objectManagerLoader: ../../../tests/object-manager.php
+    ignoreErrors:
+        # Entity のプロパティは ?type = null にしているが、該当カラムは DB 上 not-null。
+        # Symfony のフォームはバリデーションの前にデータマッピングを行い、空文字は empty_data で
+        # null になるため、非 nullable にすると保存時に TypeError で 500 になる。
+        # 実行時は Doctrine が必ず値を入れるため実害はなく、本体コアの Entity も同じ形。
+        -
+            message: '#type mapping mismatch: property can contain .+ but database expects .+#'
+            identifier: doctrine.columnType


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#95 のレビューでご提案いただいた静的解析（Rector / PHPStan / php-cs-fixer）を導入します。
あわせて、同レビュー対応中に見つかった CI のフレーク（プラグインルートが載らず PHPUnit が落ちる）を修正します。

## 方針(Policy)

- 静的解析の構成は coupon-plugin (4.4) に揃える
- 設定ファイルは配布パッケージに含めない（main.yml のパッケージングで除外）
- フレーク修正は `cache:clear` の判定に頼らず、キャッシュディレクトリを直接削除する方式

## 実装に関する補足(Appendix)

### 静的解析ジョブの追加

- `Resource/rector.php` … PHP 8.2 / Symfony 7.4 / Doctrine セット。パスは本プラグインの構成に合わせています
- `phpstan.neon.dist` … level 6。`objectManagerLoader` がカーネルを起動するため、CI では本体 + SQLite をセットアップしてから実行します
- `Resource/.php-cs-fixer.dist.php` … ライセンスヘッダの URL は本体 4.4 の `.php-cs-fixer.dist.php` に合わせ `http://` としています（coupon-plugin は `https://` のため、そのまま流用すると全ファイルにヘッダ差分が出ます）
- ci.yml に `static-analysis` ジョブを追加（DB 種別に依存しないため SQLite 1 構成で一度だけ実行）

検出された差分は次の 2 点で、いずれも本 PR に含めています。

- php-cs-fixer: コンストラクタ引数の整形 1 ファイル（挙動への影響なし）
- PHPStan: `doctrine.columnType` 4 件 → ignoreErrors で抑止

後者は Entity のプロパティが `?string` / `?int` で DB カラムが not-null という不一致の指摘です。
Symfony のフォームはバリデーションの前にデータマッピングを行い、空白のみの入力が empty_data で null になるため、プロパティ・setter を非 nullable にすると保存時に TypeError で 500 になります（#95 の blocker 指摘と同じ経路）。
実行時は Doctrine が必ず値を入れるため実害はなく、coupon-plugin と同じ抑止を入れています。

### CI フレークの修正

「`eccube:plugin:enable` して `cache:warmup` したのに、プラグインのルートがコンテナに載らず PHPUnit が RouteNotFound で落ちる」というフレークです。
4.4 マージ後の run で発生しています（[upstream: 1/8 失敗](https://github.com/EC-CUBE/ProductReview-plugin/actions/runs/31347605318)、fork: 5/8 失敗）。

原因は Symfony `CacheClearCommand` の「Cache is fresh」ショートカットです（`vendor/symfony/framework-bundle/Command/CacheClearCommand.php:124`）。

```php
if ($_SERVER['REQUEST_TIME'] <= filemtime($containerFile) && filemtime($containerFile) <= time()) {
    // fresh とみなし、--no-warmup 時はコンテナを消さずに正常終了する
```

この比較が秒精度のため、次のシーケンスが同一秒に収まると発症します。

1. `eccube:plugin:enable` が自身の kernel boot 時（DB が `enabled=0` の時点）にプラグインルートなしのコンテナをダンプする（T 秒）
2. enable 後のサブプロセス `cache:clear --no-warmup`（`PluginCommandTrait`）が T 秒内に起動 → fresh 判定でコンテナを消さない
3. 次ステップの `cache:clear --no-warmup` も T 秒内なら同様に素通り
4. `cache:warmup` はコンテナをコンパイルせず既存ダンプを再利用 → ルートなしのまま `[OK]`

裏取りはコマンドの boot 時間で取れています（約 2 秒 = コンパイル / 約 0.2 秒 = ダンプ再利用）。
失敗した job はすべて `Plugin Enabled` 以降に一度もコンパイルが起きていませんでした。

修正は `rm -rf var/cache/test` での物理削除です。
コンテナが存在しなければ warmup の boot が必ず enable 後の DB を読んでコンパイルし直すため、タイミング依存が消えます。

なお同型の問題は本体の `CacheUtil::forceClearCache()`（`cache:clear` を同一プロセスで実行するため fresh 判定が常に成立）にもあり、こちらは本体側で別途対応を検討します。

## テスト（Test)

- [x] Rector: 差分なし
- [x] php-cs-fixer: 検出 1 件を適用済み、以後差分なし
- [x] PHPStan level 6: エラーなし
- [x] PHPUnit: 18 tests / 47 assertions すべて成功（ローカル PHP 8.3 / SQLite）
- [x] fork で全ジョブ緑を 2 run 確認（8 マトリクス + static-analysis）: [run 1](https://github.com/dotani1111/ProductReview-plugin/actions/runs/31350413657) / [run 2](https://github.com/dotani1111/ProductReview-plugin/actions/runs/31361147539)

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

※ PHP の変更は php-cs-fixer による整形 1 ファイルのみで、挙動の変更はありません。
※ 追加した設定ファイルはパッケージングで除外するため、配布物にも変更はありません。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
