### PR TITLE
test: 検索テストの日付条件が実行時刻に依存して 0 件になるのを修正

### DIFF
--- a/Tests/Web/ReviewAdminControllerTest.php
+++ b/Tests/Web/ReviewAdminControllerTest.php
@@ -311,8 +311,9 @@ final class ReviewAdminControllerTest extends AbstractAdminWebTestCase
             'product_code' => $review->getProduct()->getCodeMax(),
             'sex' => [$review->getSex()->getId()],
             'recommend_level' => $review->getRecommendLevel(),
-            'review_start' => $review->getCreateDate()->modify('-2 days')->format('Y-m-d'),
-            'review_end' => $review->getCreateDate()->modify('+2 days')->format('Y-m-d'),
+            // getCreateDate() は同一インスタンスを返すため、modify で共有状態を壊さないよう clone する
+            'review_start' => (clone $review->getCreateDate())->modify('-2 days')->format('Y-m-d'),
+            'review_end' => (clone $review->getCreateDate())->modify('+2 days')->format('Y-m-d'),
         ];
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

JST 0:00〜8:59 に CI が実行されると `testReviewSearch` / `testDownloadCsv` が必ず失敗する、テストの時刻依存バグを修正します。
#101 の CI（JST 8:42 実行）で 8 ジョブすべてが同じ 2 テストで失敗し発覚しました（[該当 run](https://github.com/EC-CUBE/ProductReview-plugin/actions/runs/31547363133)）。
4.4 ブランチ自体の問題のため、push CI や他 PR でも実行時刻によって再現します。

## 原因

`initForm()` が検索条件の日付を作る際、`getCreateDate()` が返す同一の DateTime インスタンスに `modify('-2 days')` → `modify('+2 days')` を順に適用しているため相殺し、`review_end` が「投稿の 2 日後」ではなく「投稿当日」の日付になります。

これ単体では成立します（リポジトリ側が `review_end` に +1 日して終端にするため）が、create_date は UTC で保存され、検索フォームの日付は JST として解釈されるため、終端は「JST 翌日 0 時 = UTC 当日 15 時」になります。
UTC 15:00 以降（= JST 0:00〜8:59）に実行すると「UTC now」の create_date が終端を過ぎ、検索が 0 件になります。

裏取りとして、`review_end` を投稿当日にすると 0 件・翌日にすると 1 件になることをローカルで確認しています。

## 方針(Policy)

- `clone` してから `modify` し、±2 日の検索ウィンドウを意図どおりにする（3 行の修正）
- ±2 日が正しく効けば終端は投稿の 3 日後 JST 0 時となり、タイムゾーン差（最大 ±14 時間）では範囲外になり得ません

## テスト（Test)

- [x] PHPUnit: 18 tests / 47 assertions すべて成功（ローカル）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更はありません
- [x] フックポイントの呼び出しタイミングの変更はありません
- [x] フックポイントのパラメータの削除・データ型の変更はありません
- [x] twigファイルに渡しているパラメータの削除・データ型の変更はありません
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更はありません
- [x] 入出力ファイル(CSVなど)のフォーマット変更はありません

※ 変更はテストコードのみです。

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
  - [ ] 権限を超えた操作が可能にならないか
  - [ ] 不要なファイルアップロードがないか
  - [ ] 外部へ公開されるファイルや機能の追加ではないか
  - [ ] テンプレートでのエスケープ漏れがないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
